### PR TITLE
unnecessary absolute path for testdata

### DIFF
--- a/understand/circuit_test.go
+++ b/understand/circuit_test.go
@@ -74,5 +74,5 @@ func TestFaculty(t *testing.T) {
 		}
 	}()
 	ns := NewFaculty()
-	ns.UnderstandDirectory("/Users/petar/0/src/github.com/gocircuit/escher/understand/testdata")
+	ns.UnderstandDirectory("./testdata")
 }


### PR DESCRIPTION
Hey,

I think the path to `understand/testdata` doesn't have to be absolute from the root of the filesystem. `./testdata` works quite well.
