### PR TITLE
fix compile

### DIFF
--- a/faculty/focus.go
+++ b/faculty/focus.go
@@ -80,7 +80,7 @@ func (m *Eye) Focus(cognize ShortCognize) *EyeNerve {
 			ch <- struct{}{}
 		}()
 	}
-	for range m.nerve.memory.Imp.Image {
+	for _, _ = range m.nerve.memory.Imp.Image {
 		<-ch
 	}
 	close(m.nerve.connected)


### PR DESCRIPTION
did this compile with your version of go?

i got this running `go version go1.3.1 linux/amd64`

```
# github.com/gocircuit/escher/faculty
../faculty/focus.go:83: syntax error: unexpected range, expecting {
../faculty/focus.go:86: non-declaration statement outside function body
../faculty/focus.go:87: non-declaration statement outside function body
../faculty/focus.go:88: syntax error: unexpected }
```
